### PR TITLE
updates per issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,4 @@
 {
-  "ecmaFeatures": {
-    "modules": true,
-    "experimentalObjectRestSpread": true
-  },
-
   "env": {
     "browser": false,
     "es6": true,

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ TODO.md
 
 examples/*/dist
 examples/*/site
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 language: node_js
 node_js:
   - node
+  - '8'
   - '7'
   - '6'
   - '5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,9 @@ language: node_js
 node_js:
   - node
   - '8'
-  - '7'
   - '6'
-  - '5'
   - '4'
   - '0.12'
-  - '0.10'
 matrix:
   allow_failures: []
   fast_finish: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2017, Jon Schlinkert
+Copyright (c) 2015-2017, Jon Schlinkert.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# composer [![NPM version](https://img.shields.io/npm/v/composer.svg?style=flat)](https://www.npmjs.com/package/composer) [![NPM monthly downloads](https://img.shields.io/npm/dm/composer.svg?style=flat)](https://npmjs.org/package/composer)  [![NPM total downloads](https://img.shields.io/npm/dt/composer.svg?style=flat)](https://npmjs.org/package/composer) [![Linux Build Status](https://img.shields.io/travis/doowb/composer.svg?style=flat&label=Travis)](https://travis-ci.org/doowb/composer)
+# composer [![NPM version](https://img.shields.io/npm/v/composer.svg?style=flat)](https://www.npmjs.com/package/composer) [![NPM monthly downloads](https://img.shields.io/npm/dm/composer.svg?style=flat)](https://npmjs.org/package/composer)  [![NPM total downloads](https://img.shields.io/npm/dt/composer.svg?style=flat)](https://npmjs.org/package/composer) [![Linux Build Status](https://img.shields.io/travis/doowb/composer.svg?style=flat&label=Travis)](https://travis-ci.org/doowb/composer) [![Windows Build Status](https://img.shields.io/appveyor/ci/doowb/composer.svg?style=flat&label=AppVeyor)](https://ci.appveyor.com/project/doowb/composer)
 
 > API-first task runner with three methods: task, run and watch.
 
@@ -38,7 +38,7 @@ var Composer = require('composer');
 
 ## API
 
-### [.task](index.js#L62)
+### [.task](index.js#L55)
 
 Register a new task with it's options and dependencies.
 
@@ -65,7 +65,7 @@ app.task('site', ['styles'], function() {
 });
 ```
 
-### [.build](index.js#L119)
+### [.build](index.js#L113)
 
 Build a task or array of tasks.
 
@@ -84,7 +84,7 @@ app.build('default', function(err, results) {
 });
 ```
 
-### [.series](index.js#L186)
+### [.series](index.js#L180)
 
 Compose task or list of tasks into a single function that runs the tasks in series.
 
@@ -115,7 +115,7 @@ fn(function(err) {
 //=> done
 ```
 
-### [.parallel](index.js#L218)
+### [.parallel](index.js#L212)
 
 Compose task or list of tasks into a single function that runs the tasks in parallel.
 
@@ -171,31 +171,36 @@ The `.duration` property is a computed property that uses [pretty-time](https://
 
 [composer](https://github.com/doowb/composer) is an event emitter that may emit the following events:
 
-### starting
+### build
 
-This event is emitted when a `build` is starting.
-
-The event emits 2 arguments, the current instance of [composer](https://github.com/doowb/composer) as the `app` and an object containing the build runtime information.
+This event is emitted when the build is starting and when it's finished. The event emits an object containing the build runtime information.
 
 ```js
-app.on('starting', function(app, build) {});
+app.on('build', function(build) {});
 ```
 
+* `build` exposes a `.app` object that is the instance of composer.
+* `build` exposes a `.status` property that is either `starting` or `finished`.
 * `build` exposes a `.date` object that has a `.start` property containing the start time as a `Date` object.
 * `build` exposes a `.hr` object that has a `.start` property containing the start time as an `hrtime` array.
+* when `build.status` is `finished`, the `.hr` object also has `.duration` and `.diff` properties containing timing information calculated using `process.hrtime`.
 
-### finished
+### task
 
-This event is emitted when a `build` has finished.
-
-The event emits 2 arguments, the current instance of [composer](https://github.com/doowb/composer) as the `app` and an object containing the build runtime information.
+This event is emitted when the task is registered, starting, and when it's finished. The event emits 2 arguments, the current instance of the task object and an object containing the task runtime information.
 
 ```js
-app.on('finished', function(app, build) {});
+app.on('task', function(task, run) {});
 ```
+The `task` parameter exposes:
 
-* `build` exposes a `.date` object that has `.start` and `.end` properties containing start and end times of the build as `Date` objects.
-* `build` exposes a `.hr` object that has `.start`, `.end`, `.duration`, and `.diff` properties containing timing information calculated using `process.hrtime`
+* `.status` **{String}**: current status of the task. May be `register`, `starting`, or `finished`.
+
+The `run` parameter exposes:
+
+* `.date` **{Object}**: has a `.start` property containing the start time as a `Date` object.
+* `.hr` **{Object}**: has a `.start` property containing the start time as an `hrtime` array.
+* when `task.status` is `finished`, the `.hr` object also has `.duration` and `.diff` properties containing timing information calculated using `process.hrtime`.
 
 ### error
 
@@ -210,49 +215,6 @@ Additional properties:
 
 * `app`: current composer instance running the build
 * `build`: current build runtime information
-* `task`: current task instance running when the error occurred
-* `run`: current task runtime information
-
-### task:starting
-
-This event is emitted when a task is starting.
-The event emits 2 arguments, the current instance of the task object and an object containing the task runtime information.
-
-```js
-app.on('task:starting', function(task, run) {});
-```
-
-The `run` parameter exposes:
-
-* `.date` **{Object}**: has a `.start` property containing the start time as a `Date` object.
-* `.hr` **{Object}**: has a `.start` property containing the start time as an `hrtime` array.
-
-### task:finished
-
-This event is emitted when a task has finished.
-
-The event emits 2 arguments, the current instance of the task object and an object containing the task runtime information.
-
-```js
-app.on('task:finished', function(task, run) {});
-```
-
-The `run` parameter exposes:
-
-* `.date` **{Object}**: has a `.date` object that has `.start` and `.end` properties containing start and end times of the task as `Date` objects.
-* `run` **{Object}**: has an `.hr` object that has `.start`, `.end`, `.duration`, and `.diff` properties containing timing information calculated using `process.hrtime`
-
-### task:error
-
-This event is emitted when an error occurrs while running a task.
-The event emits 1 argument as an `Error` object containing additional information about the task running when the error occurred.
-
-```js
-app.on('task:error', function(err) {});
-```
-
-**Additional properties**
-
 * `task`: current task instance running when the error occurred
 * `run`: current task runtime information
 
@@ -369,7 +331,7 @@ Pull requests and stars are always welcome. For bugs and feature requests, [plea
 
 | **Commits** | **Contributor** |  
 | --- | --- |  
-| 195 | [doowb](https://github.com/doowb) |  
+| 207 | [doowb](https://github.com/doowb) |  
 | 36  | [jonschlinkert](https://github.com/jonschlinkert) |  
 
 ### Building docs
@@ -404,4 +366,4 @@ Released under the [MIT License](LICENSE).
 
 ***
 
-_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on May 26, 2017._
+_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on September 12, 2017._

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+# Test against this version of Node.js
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: "8.0"
+    - nodejs_version: "7.0"
+    - nodejs_version: "6.0"
+    - nodejs_version: "5.0"
+    - nodejs_version: "4.0"
+    - nodejs_version: "0.12"
+    - nodejs_version: "0.10"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,11 @@
 environment:
   matrix:
     # node.js
+    - nodejs_version: "9.0"
     - nodejs_version: "8.0"
-    - nodejs_version: "7.0"
     - nodejs_version: "6.0"
-    - nodejs_version: "5.0"
     - nodejs_version: "4.0"
     - nodejs_version: "0.12"
-    - nodejs_version: "0.10"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,30 +1,34 @@
 [composer][] is an event emitter that may emit the following events:
 
-### starting
+### build
 
-This event is emitted when a `build` is starting.
-
-The event emits 2 arguments, the current instance of [composer][] as the `app` and an object containing the build runtime information.
+This event is emitted when the build is starting and when it's finished. The event emits an object containing the build runtime information.
 
 ```js
-app.on('starting', function(app, build) {});
+app.on('build', function(build) {});
 ```
-
+* `build` exposes a `.app` object that is the instance of composer.
+* `build` exposes a `.status` property that is either `starting` or `finished`.
 * `build` exposes a `.date` object that has a `.start` property containing the start time as a `Date` object.
 * `build` exposes a `.hr` object that has a `.start` property containing the start time as an `hrtime` array.
+* when `build.status` is `finished`, the `.hr` object also has `.duration` and `.diff` properties containing timing information calculated using `process.hrtime`.
 
-### finished
+### task
 
-This event is emitted when a `build` has finished.
-
-The event emits 2 arguments, the current instance of [composer][] as the `app` and an object containing the build runtime information.
+This event is emitted when the task is registered, starting, and when it's finished. The event emits 2 arguments, the current instance of the task object and an object containing the task runtime information.
 
 ```js
-app.on('finished', function(app, build) {});
+app.on('task', function(task, run) {});
 ```
+The `task` parameter exposes:
 
-* `build` exposes a `.date` object that has `.start` and `.end` properties containing start and end times of the build as `Date` objects.
-* `build` exposes a `.hr` object that has `.start`, `.end`, `.duration`, and `.diff` properties containing timing information calculated using `process.hrtime`
+* `.status` **{String}**: current status of the task. May be `register`, `starting`, or `finished`.
+
+The `run` parameter exposes:
+
+* `.date` **{Object}**: has a `.start` property containing the start time as a `Date` object.
+* `.hr` **{Object}**: has a `.start` property containing the start time as an `hrtime` array.
+* when `task.status` is `finished`, the `.hr` object also has `.duration` and `.diff` properties containing timing information calculated using `process.hrtime`.
 
 ### error
 
@@ -39,48 +43,5 @@ Additional properties:
 
 * `app`: current composer instance running the build
 * `build`: current build runtime information
-* `task`: current task instance running when the error occurred
-* `run`: current task runtime information
-
-### task:starting
-
-This event is emitted when a task is starting.
-The event emits 2 arguments, the current instance of the task object and an object containing the task runtime information.
-
-```js
-app.on('task:starting', function(task, run) {});
-```
-
-The `run` parameter exposes:
-
-* `.date` **{Object}**: has a `.start` property containing the start time as a `Date` object.
-* `.hr` **{Object}**: has a `.start` property containing the start time as an `hrtime` array.
-
-### task:finished
-
-This event is emitted when a task has finished.
-
-The event emits 2 arguments, the current instance of the task object and an object containing the task runtime information.
-
-```js
-app.on('task:finished', function(task, run) {});
-```
-
-The `run` parameter exposes:
-
-* `.date` **{Object}**: has a `.date` object that has `.start` and `.end` properties containing start and end times of the task as `Date` objects.
-* `run` **{Object}**: has an `.hr` object that has `.start`, `.end`, `.duration`, and `.diff` properties containing timing information calculated using `process.hrtime`
-
-### task:error
-
-This event is emitted when an error occurrs while running a task.
-The event emits 1 argument as an `Error` object containing additional information about the task running when the error occurred.
-
-```js
-app.on('task:error', function(err) {});
-```
-
-**Additional properties**
-
 * `task`: current task instance running when the error occurred
 * `run`: current task runtime information

--- a/index.js
+++ b/index.js
@@ -104,29 +104,31 @@ Composer.prototype.task = function(name/*, options, deps, task */) {
  * });
  * ```
  *
- * @param {String|Array|Function} `tasks` List of tasks by name, function, or array of names/functions. (Defaults to `[default]`).
+ * @param {String|Array} `tasks` Array of task names to build. (Defaults to `[default]`).
  * @param {Object} `options` Optional options object to merge onto each task's options when building.
- * @param {Function} `cb` Callback function to be called when all tasks are finished building.
+ * @param {Function} `cb` Optional callback function to be called when all tasks are finished building. If omitted, a Promise is returned.
+ * @return {Promise} When `cb` is omitted, a Promise is returned that will resolve when the tasks are finished building.
  * @api public
  */
 
-Composer.prototype.build = function(/* [tasks,] [options,] callback */) {
-  var args = [].concat.apply([], [].slice.call(arguments));
-  var done = args.pop();
-  if (typeof done !== 'function') {
-    throw new TypeError('Expected the last argument to be a callback function, but got `' + typeof done + '`.');
+Composer.prototype.build = function(tasks, options, cb) {
+  if (typeof options === 'function') {
+    cb = options;
+    options = null;
   }
 
-  var options = {};
-  if (args.length && utils.isobject(args[args.length - 1])) {
-    options = args.pop();
+  if (typeof tasks === 'function') {
+    cb = tasks;
+    tasks = [];
   }
 
-  if (args.length === 0) {
-    args = ['default'];
+  tasks = utils.arrayify(tasks);
+  if (tasks.length === 0) {
+    tasks = ['default'];
   }
 
-  args.push(options);
+  var opts = utils.extend({}, options);
+  tasks.push(opts);
 
   // gather total build time information
   var self = this;
@@ -134,20 +136,33 @@ Composer.prototype.build = function(/* [tasks,] [options,] callback */) {
   utils.define(build, 'app', this);
   build.start();
   this.emit('build', build);
-  function finishBuild(err) {
-    build.end();
-    if (err) {
-      utils.define(err, 'app', self);
-      utils.define(err, 'build', build);
-      self.emit('error', err);
-    } else {
-      self.emit('build', build);
-    }
-    return done.apply(null, arguments);
-  };
+  var fn = this.series.apply(this, tasks);
 
-  var fn = this.series.apply(this, args);
-  return fn(finishBuild);
+  return new Promise(function(resolve, reject) {
+    fn(function(err, result) {
+      build.end();
+      if (err) {
+        utils.define(err, 'app', self);
+        utils.define(err, 'build', build);
+        self.emit('error', err);
+        reject(err);
+      } else {
+        self.emit('build', build);
+        resolve(result);
+      }
+    });
+  })
+  .then(function(result) {
+    if (typeof cb === 'function') {
+      cb(null, result);
+    }
+    return result;
+  })
+  .catch(function(err) {
+    if (typeof cb === 'function') {
+      cb(err);
+    }
+  });
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var map = require('./lib/map-deps');
 var inspect = require('./lib/inspect');
 var flowFactory = require('./lib/flow');
 var Emitter = require('component-emitter');
-var builds = [];
+var runId = 0;
 
 /**
  * Composer constructor. Create an instance of `Composer`
@@ -21,13 +21,6 @@ var builds = [];
 function Composer(name) {
   Emitter.call(this);
   this.tasks = {};
-  utils.define(this, '_appname', name || this._appname || 'composer');
-  utils.define(this, 'buildHistory', {
-    configurable: true,
-    get: function() {
-      return builds;
-    }
-  });
 }
 
 /**
@@ -136,8 +129,7 @@ Composer.prototype.build = function(/* [tasks,] [options,] callback */) {
 
   // gather total build time information
   var self = this;
-  var build = new Run(builds.length);
-  builds.push(build);
+  var build = new Run(runId++);
   build.start();
   this.emit('starting', this, build);
   function finishBuild(err) {

--- a/index.js
+++ b/index.js
@@ -161,7 +161,9 @@ Composer.prototype.build = function(tasks, options, cb) {
   .catch(function(err) {
     if (typeof cb === 'function') {
       cb(err);
+      return;
     }
+    throw err;
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -84,12 +84,13 @@ Composer.prototype.task = function(name/*, options, deps, task */) {
   inspect(this, task);
 
   // bubble up events from tasks
-  task.on('starting', this.emit.bind(this, 'task:starting'));
-  task.on('finished', this.emit.bind(this, 'task:finished'));
-  task.on('error', this.emit.bind(this, 'task:error'));
+  task.on('starting', this.emit.bind(this, 'task'));
+  task.on('finished', this.emit.bind(this, 'task'));
+  task.on('error', this.emit.bind(this, 'error'));
 
   this.tasks[name] = task;
-  this.emit('task', this.name, task);
+  task.status = 'register';
+  this.emit('task', task);
   return this;
 };
 
@@ -130,8 +131,9 @@ Composer.prototype.build = function(/* [tasks,] [options,] callback */) {
   // gather total build time information
   var self = this;
   var build = new Run(runId++);
+  utils.define(build, 'app', this);
   build.start();
-  this.emit('starting', this, build);
+  this.emit('build', build);
   function finishBuild(err) {
     build.end();
     if (err) {
@@ -139,7 +141,7 @@ Composer.prototype.build = function(/* [tasks,] [options,] callback */) {
       utils.define(err, 'build', build);
       self.emit('error', err);
     } else {
-      self.emit('finished', self, build);
+      self.emit('build', build);
     }
     return done.apply(null, arguments);
   };

--- a/lib/run.js
+++ b/lib/run.js
@@ -74,6 +74,7 @@ function Run(id) {
  */
 
 Run.prototype.start = function() {
+  this.status = 'starting';
   this.date.start = new Date();
   this.hr.start = process.hrtime();
 };
@@ -91,6 +92,7 @@ Run.prototype.end = function() {
   this.hr.end = process.hrtime();
   this.duration = process.hrtime(this.hr.start);
   this.date.end = new Date();
+  this.status = 'finished';
 };
 
 /**

--- a/lib/run.js
+++ b/lib/run.js
@@ -89,7 +89,7 @@ Run.prototype.start = function() {
 
 Run.prototype.end = function() {
   this.hr.end = process.hrtime();
-  this.hr.duration = process.hrtime(this.hr.start);
+  this.duration = process.hrtime(this.hr.start);
   this.date.end = new Date();
 };
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -26,6 +26,8 @@ function Run(id) {
    */
 
   utils.define(this, 'duration', {
+    enumerable: true,
+    configurable: true,
     get: function() {
       if (typeof this.hr.duration === 'undefined') {
         if (typeof this.hr.start === 'undefined') {
@@ -48,6 +50,8 @@ function Run(id) {
    */
 
   utils.define(this.hr, 'diff', {
+    enumerable: true,
+    configurable: true,
     get: function() {
       return utils.nano(this.end) - utils.nano(this.start);
     }
@@ -63,6 +67,8 @@ function Run(id) {
    */
 
   utils.define(this.hr, 'offset', {
+    enumerable: true,
+    configurable: true,
     get: function() {
       return utils.nano(this.duration) - this.diff;
     }

--- a/lib/task.js
+++ b/lib/task.js
@@ -54,10 +54,12 @@ Task.prototype.setupRun = function(cb) {
   var run = new Run(this._runs.length);
   utils.define(this, 'runInfo', run);
   this._runs.push(run);
+  this.status = 'starting';
   run.start();
   this.emit('starting', this, run);
   return function finishRun(err) {
     run.end();
+    self.status = 'finished';
     if (err) {
       utils.define(err, 'task', self);
       utils.define(err, 'run', run);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0"
   },
   "scripts": {
     "test": "mocha"

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -30,6 +30,18 @@ describe('parallel', function() {
     });
   });
 
+  it('should return an error when no functions are passed to parallel', function(done) {
+    var fn = composer.parallel();
+    fn(function(err) {
+      if (!err) {
+        done(new Error('expected an error'));
+        return;
+      }
+      assert.equal(err.message, 'A set of functions to combine is required');
+      done();
+    });
+  });
+
   it('should compose tasks with options into a function that runs in parallel', function(done) {
     var output = [];
     composer.task('foo', {silent: false}, function(cb) {

--- a/test/series.js
+++ b/test/series.js
@@ -47,6 +47,18 @@ describe('series', function() {
     });
   });
 
+  it('should return an error when no functions are passed to series', function(done) {
+    var fn = composer.series();
+    fn(function(err) {
+      if (!err) {
+        done(new Error('expected an error'));
+        return;
+      }
+      assert.equal(err.message, 'A set of functions to combine is required');
+      done();
+    });
+  });
+
   it('should compose tasks with additional options into a function that runs in series', function(done) {
     var output = [];
     composer.task('foo', {silent: false}, function(cb) {

--- a/test/task.js
+++ b/test/task.js
@@ -141,6 +141,24 @@ describe('task', function() {
     });
   });
 
+  it('should run a task that returns a non stream when `.run` is called', function(done) {
+    var count = 0;
+    var fn = function(cb) {
+      setImmediate(function() {
+        count++;
+        cb();
+      });
+      return count;
+    };
+
+    var task = new Task({name: 'default', fn: fn});
+    task.run(function(err) {
+      if (err) return done(err);
+      assert.equal(count, 1);
+      done();
+    });
+  });
+
   it('should emit a `starting` event when the task starts running', function(done) {
     var count = 0;
     var fn = function(cb) {

--- a/test/test.js
+++ b/test/test.js
@@ -269,14 +269,6 @@ describe('composer', function() {
     });
   });
 
-  it('should throw an error when `.build` is called without a callback function.', function() {
-    try {
-      composer.build('default');
-      throw new Error('Expected an error to be thrown.');
-    } catch (err) {
-    }
-  });
-
   it('should emit task events', function(done) {
     var events = [];
     composer.on('task', function(task) {

--- a/test/test.js
+++ b/test/test.js
@@ -109,6 +109,19 @@ describe('composer', function() {
     });
   });
 
+  it('should run a task and return a promise', function() {
+    var count = 0;
+    composer.task('default', function(cb) {
+      count++;
+      cb();
+    });
+
+    return composer.build('default')
+      .then(function() {
+        assert.equal(count, 1);
+      });
+  });
+
   it('should run a task with options', function(done) {
     var count = 0;
     composer.task('default', {silent: false}, function(cb) {
@@ -376,6 +389,23 @@ describe('composer', function() {
       if (err) return done();
       done(new Error('Expected an error'));
     });
+  });
+
+  it('should emit a build error event when an error is passed back in a task (with promise)', function(done) {
+    composer.on('error', function(err) {
+      assert(err);
+      assert.equal(err.message, 'in task "default": This is an error');
+    });
+    composer.task('default', function(cb) {
+      return cb(new Error('This is an error'));
+    });
+    composer.build('default')
+      .then(function() {
+        done(new Error('Expected an error'));
+      })
+      .catch(function(err) {
+        done();
+      })
   });
 
   it('should emit a build error event when an error is thrown in a task', function(done) {

--- a/test/test.js
+++ b/test/test.js
@@ -337,13 +337,13 @@ describe('composer', function() {
   it('should emit build events', function(done) {
     var events = [];
     composer.on('starting', function(app, run) {
-      events.push('starting.' + app._appname);
+      events.push('starting');
     });
     composer.on('finished', function(app, run) {
-      events.push('finished.' + app._appname);
+      events.push('finished');
     });
     composer.on('error', function(err) {
-      events.push('error.' + err.app._appname);
+      events.push('error');
     });
 
     composer.task('foo', function(cb) {
@@ -355,7 +355,7 @@ describe('composer', function() {
     composer.task('default', ['bar']);
     composer.build('default', function(err) {
       if (err) return done(err);
-      assert.deepEqual(events, ['starting.composer', 'finished.composer']);
+      assert.deepEqual(events, ['starting', 'finished']);
       done();
     });
   });
@@ -510,26 +510,6 @@ describe('composer', function() {
     }
     composer.build(tasks, function(err) {
       if (err) return done(err);
-      assert.equal(results.length, 10);
-      assert.deepEqual(results, ['task-0', 'task-1', 'task-2', 'task-3', 'task-4', 'task-5', 'task-6', 'task-7', 'task-8', 'task-9']);
-      done();
-    });
-  });
-
-  it('should get the build history after a build', function(done) {
-    var results = [];
-    var fn = function(cb) {
-      results.push(this.name);
-      cb();
-    };
-    var tasks = [];
-    for (var i = 0; i < 10; i++) {
-      tasks.push('task-' + i);
-      composer.task('task-' + i, fn);
-    }
-    composer.build(tasks, function(err) {
-      if (err) return done(err);
-      assert(composer.buildHistory.length > 0);
       assert.equal(results.length, 10);
       assert.deepEqual(results, ['task-0', 'task-1', 'task-2', 'task-3', 'task-4', 'task-5', 'task-6', 'task-7', 'task-8', 'task-9']);
       done();

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var assert = require('assert');
+var utils = require('../lib/utils');
+
+describe('utils', function() {
+  describe('arrayify', function() {
+    it('should return an empty array when falsey', function() {
+      assert.deepEqual(utils.arrayify(false), []);
+    });
+
+    it('should return an array when given a non array', function() {
+      assert.deepEqual(utils.arrayify('foo'), ['foo']);
+    });
+
+    it('should return an array when given an array', function() {
+      assert.deepEqual(utils.arrayify(['foo']), ['foo']);
+    });
+  });
+
+  describe('formatError', function() {
+    it('should return the error when task is undefined', function() {
+      var error = new Error('some error');
+      assert.equal(utils.formatError(error), error);
+    });
+
+    it('should format the error message when a task property is on the error', function() {
+      var error = new Error('some error');
+      error.task = {name: 'foo'};
+      assert.equal(utils.formatError(error).message, 'in task "foo": some error');
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses a few issues:

 - [x] #24 removing unused properties
 - [x] #21 and #20 refactors events so only 3 events are emitted:
   * `task` when a task is `register`ed, `starting`, and `finished`. Task emitted with `status` populated.
   * `build` when a build is `starting` and `finished`. Build has runtime information and `status` populated.
   * `error` on errors with additional `.app`, `.task`, and `.build` properties

TODO: before merging finish up a couple other issues:

 - [x] #28 return promise from `.build`
   * when `cb` is not passed in, return promise
   * only accept 3 parameters `(tasks, options, cb)`
 - [x] #23 add human readable formatted time and duration properties